### PR TITLE
fix: item with colon in map can not be parsed correctly

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  [push, pull_request]
+
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: leafo/gh-actions-lua@v8
+      - uses: leafo/gh-actions-luarocks@v4
+
+      - name: install lua rocks
+        run: luarocks install busted luassert
+
+      - name: run test
+        run: busted spec/

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,6 +6,10 @@ on:
 
 jobs:
   ci:
+    strategy:
+      matrix:
+        luaVersion: ["5.1", "5.2", "5.3", "5.4", "luajit"]
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
@@ -13,7 +17,9 @@ jobs:
       - uses: leafo/gh-actions-luarocks@v4
 
       - name: install lua rocks
-        run: luarocks install busted luassert
+        run: |
+          luarocks install busted
+          luarocks install luassert
 
       - name: run test
         run: busted spec/

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,8 +12,10 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@master
       - uses: leafo/gh-actions-lua@v8
+        with:
+          luaVersion: ${{ matrix.luaVersion }}
       - uses: leafo/gh-actions-luarocks@v4
 
       - name: install lua rocks

--- a/spec/map_spec.lua
+++ b/spec/map_spec.lua
@@ -1,0 +1,43 @@
+-- .vscode/settings.json <<
+--   "Lua.workspace.library": {
+--     "C:\\ProgramData\\chocolatey\\lib\\luarocks\\luarocks-2.4.4-win32\\systree\\share\\lua\\5.1": true
+--   },
+local busted = require 'busted'
+local assert = require 'luassert'
+local yaml = require 'tinyyaml'
+
+busted.describe("map", function()
+
+  busted.it("map with colon for item", function()
+
+    assert.same(
+        {
+          value = {"a:1"}
+        },
+        yaml.parse([[
+          value:
+            - a:1
+        ]])
+      )
+
+    assert.same(
+        {
+          value = {"a:1"}
+        },
+        yaml.parse([[
+          value:
+            - "a:1"
+        ]])
+      )
+
+      assert.same(
+        {
+          value = {{a = 1}}
+        },
+        yaml.parse([[
+          value:
+            - a: 1
+        ]])
+      )
+  end)
+end)

--- a/tinyyaml.lua
+++ b/tinyyaml.lua
@@ -15,7 +15,6 @@ local tonumber = tonumber
 local math = math
 local getmetatable = getmetatable
 local error = error
-local inspect = require("inspect")
 
 local UNESCAPES = {
   ['0'] = "\x00", z = "\x00", N    = "\x85",

--- a/tinyyaml.lua
+++ b/tinyyaml.lua
@@ -15,6 +15,7 @@ local tonumber = tonumber
 local math = math
 local getmetatable = getmetatable
 local error = error
+local inspect = require("inspect")
 
 local UNESCAPES = {
   ['0'] = "\x00", z = "\x00", N    = "\x85",
@@ -510,7 +511,7 @@ local function parseseq(line, lines, indent)
     end
     local rest = ssub(line, j+1)
 
-    if sfind(rest, '^[^\'\"%s]*:') then
+    if sfind(rest, '^[^\'\"%s]*:%s') then
       -- Inline nested hash
       local indent2 = j
       lines[1] = string.rep(' ', indent2)..rest


### PR DESCRIPTION
Signed-off-by: yiyiyimu <wosoyoung@gmail.com>

fix https://github.com/apache/apisix/issues/4449

Inline nested hash should have an extra space after the colon

https://github.com/peposso/lua-tinyyaml/blob/e11d16d21200846719a8e03b7f0d00ff37c5b961/tinyyaml.lua#L513-L514

---

Also add CI for easier test and test passed in my forked repo
https://github.com/Yiyiyimu/lua-tinyyaml/actions/runs/953567969