### PR TITLE
feat: Add option to disable the timestamp parser

### DIFF
--- a/tinyyaml.lua
+++ b/tinyyaml.lua
@@ -455,9 +455,11 @@ local function parsescalar(line, lines, indent)
     return null
   end
 
-  local ts, _ = parsetimestamp(line)
-  if ts then
-    return ts
+  if options.timestamps ~= false then
+    local ts, _ = parsetimestamp(line)
+    if ts then
+      return ts
+    end
   end
 
   local s, _ = parsestring(line)

--- a/tinyyaml.lua
+++ b/tinyyaml.lua
@@ -189,6 +189,13 @@ local function checkdupekey(map, key)
   return key
 end
 
+--- Parse yaml string into table.
+local function parse(source, options)
+
+  if options == nil then
+    options = {}
+  end
+
 local function parsestring(line, stopper)
   stopper = stopper or ''
   local q = ssub(line, 1, 1)
@@ -801,19 +808,20 @@ local function parsedocuments(lines)
   return root
 end
 
---- Parse yaml string into table.
-local function parse(source)
-  local lines = {}
-  for line in string.gmatch(source .. '\n', '(.-)\r?\n') do
-    tinsert(lines, line)
-  end
+--- Parse yaml string into table depending on options
+  local function parse_inner (source)
+    local lines = {}
+    for line in string.gmatch(source .. '\n', '(.-)\r?\n') do
+      tinsert(lines, line)
+    end
 
-  local docs = parsedocuments(lines)
-  if #docs == 1 then
-    return docs[1]
+    local docs = parsedocuments(lines)
+    if #docs == 1 then
+      return docs[1]
+    end
+    return docs
   end
-
-  return docs
+  return parse_inner(source)
 end
 
 return {


### PR DESCRIPTION
This library is used by the LaTeX markdown package to parse jekyll headers. I just got confused by the standard behavior of the timestamp parser because it's not a YAML core data type. Therefore I'd really love to be able to turn it off. 

@Witiko suggested to do this within a closure to be able to use the library with different options per instance. This required to move all parse functions into the closure which will hide them from direct access. As far as we discussed it this shouldn't be an issue because the public interface is the parse-function itself. But we wanted you to be aware of this. 

If there's anything else I can do to get this option, please let me know. 

The corresponding issue is https://github.com/Witiko/markdown/issues/114